### PR TITLE
chore: fix makefile install command compatibility

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/openzeppelin/openzeppelin-contracts-upgradeable
 [submodule "lib/foundry-devops"]
 	path = lib/foundry-devops
-	url = https://github.com/Cyfrin/foundry-devops
+	url = https://github.com/cyfrin/foundry-devops

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ clean  :; forge clean
 # Remove modules
 remove :; rm -rf .gitmodules && rm -rf .git/modules/* && rm -rf lib && touch .gitmodules && git add . && git commit -m "modules"
 
-install :; forge install foundry-rs/forge-std --no-commit && forge install openzeppelin/openzeppelin-contracts@v4.8.3 --no-commit && forge install openzeppelin/openzeppelin-contracts-upgradeable@v4.8.3 --no-commit && forge install cyfrin/foundry-devops@0.0.11 --no-commit 
+install :; forge install foundry-rs/forge-std && forge install openzeppelin/openzeppelin-contracts@v4.8.3 && forge install openzeppelin/openzeppelin-contracts-upgradeable@v4.8.3 && forge install cyfrin/foundry-devops@0.0.11
 
 # Update Dependencies
 update:; forge update


### PR DESCRIPTION
## Description
Removes the `--no-commit` flag from the `install` command in the Makefile.

## Motivation
Newer versions of Foundry/Forge manage git submodules differently, and the `--no-commit` flag often causes installation errors or is redundant in current workflows. Removing it ensures the `make install` command runs smoothly for users on the latest Foundry version.

## Changes
- Removed `--no-commit` from `forge install` commands in Makefile.